### PR TITLE
Upgrade mysql-connector-python to version 8.0.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jeepney==0.4
 keyring==19.0.2
 mock==3.0.5
 more-itertools==7.2.0
-mysql-connector-python==8.0.17
+mysql-connector-python==8.0.20
 packaging==19.1
 pluggy==0.12.0
 protobuf==3.9.0


### PR DESCRIPTION
Resolves stacktraces like 

```
$ bcc --store-password
2020-06-03 13:02:25,864 INFO - mysql_tracer.cursor_provider: Did not find password in keyring, asking for password...
Password for arichir@127.0.0.1: 
Traceback (most recent call last):
  File "/home/arichir/.local/bin/bcc", line 8, in <module>
    sys.exit(main())
  File "/home/arichir/.local/lib/python3.8/site-packages/billing_check/__main__.py", line 77, in main
    cursor_provider.CursorProvider.init(args.host, args.user, args.port, args.database, args.ask_password,
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql_tracer/cursor_provider.py", line 23, in init
    CursorProvider.instance = CursorProvider.__CursorProvider(host, user, port, database, ask_password,
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql_tracer/cursor_provider.py", line 45, in __init__
    self.connect_with_retry(host, port, user, database, service, store_password)
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql_tracer/cursor_provider.py", line 53, in connect_with_retry
    self.connection = connector.connect(host=host, port=port, user=user, db=database, password=password)
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql/connector/__init__.py", line 173, in connect
    return MySQLConnection(*args, **kwargs)
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql/connector/connection.py", line 104, in __init__
    self.connect(**kwargs)
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql/connector/abstracts.py", line 777, in connect
    self.config(**kwargs)
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql/connector/abstracts.py", line 404, in config
    self._add_default_conn_attrs()
  File "/home/arichir/.local/lib/python3.8/site-packages/mysql/connector/connection.py", line 126, in _add_default_conn_attrs
    os_ver = "-".join(platform.linux_distribution()[0:2]) # pylint: disable=W1505
AttributeError: module 'platform' has no attribute 'linux_distribution'
```